### PR TITLE
ARP: resolve IP multicast

### DIFF
--- a/rtl/arp.v
+++ b/rtl/arp.v
@@ -364,6 +364,11 @@ always @* begin
                 arp_response_valid_next = 1'b1;
                 arp_response_error_next = 1'b0;
                 arp_response_mac_next = 48'hffffffffffff;
+            end else if (arp_request_ip[31 -: 4] == 4'b1110) begin
+                // multicast
+                arp_response_valid_next = 1'b1;
+                arp_response_error_next = 1'b0;
+                arp_response_mac_next = {24'h01005e, 1'b0, arp_request_ip[22:0]};
             end else if (((arp_request_ip ^ gateway_ip) & subnet_mask) == 0) begin
                 // within subnet, look up IP directly
                 // (no bits differ between request IP and gateway IP where subnet mask is set)

--- a/tb/test_arp.py
+++ b/tb/test_arp.py
@@ -279,7 +279,7 @@ def bench():
         yield delay(100)
 
         yield clk.posedge
-        print("test 3: Unached read")
+        print("test 3: Uncached read")
         current_test.next = 3
 
         arp_request_source.send([(0xc0a80166,)])

--- a/tb/test_arp.py
+++ b/tb/test_arp.py
@@ -435,6 +435,15 @@ def bench():
         assert not err
         assert mac == 0xffffffffffff
 
+        # multicast
+        arp_request_source.send([(0xe0000181,)])
+
+        yield arp_response_sink.wait()
+        err, mac = arp_response_sink.recv().data[0]
+
+        assert not err
+        assert mac == 0x01005e000181
+
         yield delay(100)
 
         raise StopSimulation


### PR DESCRIPTION
According to [RFC1112](https://tools.ietf.org/html/rfc1112), addresses 224.0.0.0 – 239.255.255.255 (starting 0b1110) should be resolved by placing the low-order 23-bits of the IP address into the low-23 bits of the Ethernet multicast address 01-00-5E-00-00-00. Another explanation [here](https://networklessons.com/multicast/multicast-ip-address-to-mac-address-mapping).
This allows, for instance, sending multicast PTP packets to 224.0.1.129, which maps to 01:00:5e:00:01:81.