### PR TITLE
Minor fixes and improvements

### DIFF
--- a/example/ADM_PCIE_9V3/fpga_10g/rtl/fpga.v
+++ b/example/ADM_PCIE_9V3/fpga_10g/rtl/fpga.v
@@ -285,11 +285,27 @@ wire qsfp_0_rx_block_lock_0;
 wire qsfp_0_rx_block_lock_1;
 wire qsfp_0_rx_block_lock_2;
 wire qsfp_0_rx_block_lock_3;
+reg qsfp0_rx_prbs31_enable_0 = 1'b0;
+reg qsfp0_rx_prbs31_enable_1 = 1'b0;
+reg qsfp0_rx_prbs31_enable_2 = 1'b0;
+reg qsfp0_rx_prbs31_enable_3 = 1'b0;
+reg qsfp0_tx_prbs31_enable_0 = 1'b0;
+reg qsfp0_tx_prbs31_enable_1 = 1'b0;
+reg qsfp0_tx_prbs31_enable_2 = 1'b0;
+reg qsfp0_tx_prbs31_enable_3 = 1'b0;
 
 wire qsfp_1_rx_block_lock_0;
 wire qsfp_1_rx_block_lock_1;
 wire qsfp_1_rx_block_lock_2;
 wire qsfp_1_rx_block_lock_3;
+reg qsfp1_rx_prbs31_enable_0 = 1'b0;
+reg qsfp1_rx_prbs31_enable_1 = 1'b0;
+reg qsfp1_rx_prbs31_enable_2 = 1'b0;
+reg qsfp1_rx_prbs31_enable_3 = 1'b0;
+reg qsfp1_tx_prbs31_enable_0 = 1'b0;
+reg qsfp1_tx_prbs31_enable_1 = 1'b0;
+reg qsfp1_tx_prbs31_enable_2 = 1'b0;
+reg qsfp1_tx_prbs31_enable_3 = 1'b0;
 
 wire qsfp_0_mgt_refclk;
 wire qsfp_1_mgt_refclk;
@@ -531,17 +547,25 @@ qsfp_0_phy_0_inst (
     .tx_rst(qsfp_0_tx_rst_0_int),
     .rx_clk(qsfp_0_rx_clk_0_int),
     .rx_rst(qsfp_0_rx_rst_0_int),
+    // XGMII interface
     .xgmii_txd(qsfp_0_txd_0_int),
     .xgmii_txc(qsfp_0_txc_0_int),
     .xgmii_rxd(qsfp_0_rxd_0_int),
     .xgmii_rxc(qsfp_0_rxc_0_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_0_gt_txdata_0),
     .serdes_tx_hdr(qsfp_0_gt_txheader_0),
     .serdes_rx_data(qsfp_0_gt_rxdata_0),
     .serdes_rx_hdr(qsfp_0_gt_rxheader_0),
     .serdes_rx_bitslip(qsfp_0_gt_rxgearboxslip_0),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_0_rx_block_lock_0),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_0_tx_prbs31_enable_0),
+    .rx_prbs31_enable(qsfp_0_rx_prbs31_enable_0)
 );
 
 assign qsfp_0_tx_clk_1_int = clk_156mhz_int;
@@ -566,17 +590,25 @@ qsfp_0_phy_1_inst (
     .tx_rst(qsfp_0_tx_rst_1_int),
     .rx_clk(qsfp_0_rx_clk_1_int),
     .rx_rst(qsfp_0_rx_rst_1_int),
+    // XGMII interface
     .xgmii_txd(qsfp_0_txd_1_int),
     .xgmii_txc(qsfp_0_txc_1_int),
     .xgmii_rxd(qsfp_0_rxd_1_int),
     .xgmii_rxc(qsfp_0_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_0_gt_txdata_1),
     .serdes_tx_hdr(qsfp_0_gt_txheader_1),
     .serdes_rx_data(qsfp_0_gt_rxdata_1),
     .serdes_rx_hdr(qsfp_0_gt_rxheader_1),
     .serdes_rx_bitslip(qsfp_0_gt_rxgearboxslip_1),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_0_rx_block_lock_1),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_0_tx_prbs31_enable_1),
+    .rx_prbs31_enable(qsfp_0_rx_prbs31_enable_1)
 );
 
 assign qsfp_0_tx_clk_2_int = clk_156mhz_int;
@@ -601,17 +633,25 @@ qsfp_0_phy_2_inst (
     .tx_rst(qsfp_0_tx_rst_2_int),
     .rx_clk(qsfp_0_rx_clk_2_int),
     .rx_rst(qsfp_0_rx_rst_2_int),
+    // XGMII interface
     .xgmii_txd(qsfp_0_txd_2_int),
     .xgmii_txc(qsfp_0_txc_2_int),
     .xgmii_rxd(qsfp_0_rxd_2_int),
     .xgmii_rxc(qsfp_0_rxc_2_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_0_gt_txdata_2),
     .serdes_tx_hdr(qsfp_0_gt_txheader_2),
     .serdes_rx_data(qsfp_0_gt_rxdata_2),
     .serdes_rx_hdr(qsfp_0_gt_rxheader_2),
     .serdes_rx_bitslip(qsfp_0_gt_rxgearboxslip_2),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_0_rx_block_lock_2),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_0_tx_prbs31_enable_2),
+    .rx_prbs31_enable(qsfp_0_rx_prbs31_enable_2)
 );
 
 assign qsfp_0_tx_clk_3_int = clk_156mhz_int;
@@ -636,17 +676,25 @@ qsfp_0_phy_3_inst (
     .tx_rst(qsfp_0_tx_rst_3_int),
     .rx_clk(qsfp_0_rx_clk_3_int),
     .rx_rst(qsfp_0_rx_rst_3_int),
+    // XGMII interface
     .xgmii_txd(qsfp_0_txd_3_int),
     .xgmii_txc(qsfp_0_txc_3_int),
     .xgmii_rxd(qsfp_0_rxd_3_int),
     .xgmii_rxc(qsfp_0_rxc_3_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_0_gt_txdata_3),
     .serdes_tx_hdr(qsfp_0_gt_txheader_3),
     .serdes_rx_data(qsfp_0_gt_rxdata_3),
     .serdes_rx_hdr(qsfp_0_gt_rxheader_3),
     .serdes_rx_bitslip(qsfp_0_gt_rxgearboxslip_3),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_0_rx_block_lock_3),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_0_tx_prbs31_enable_3),
+    .rx_prbs31_enable(qsfp_0_rx_prbs31_enable_3)
 );
 
 assign qsfp_1_tx_clk_0_int = clk_156mhz_int;
@@ -671,17 +719,25 @@ qsfp_1_phy_0_inst (
     .tx_rst(qsfp_1_tx_rst_0_int),
     .rx_clk(qsfp_1_rx_clk_0_int),
     .rx_rst(qsfp_1_rx_rst_0_int),
+    // XGMII interface
     .xgmii_txd(qsfp_1_txd_0_int),
     .xgmii_txc(qsfp_1_txc_0_int),
     .xgmii_rxd(qsfp_1_rxd_0_int),
     .xgmii_rxc(qsfp_1_rxc_0_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_1_gt_txdata_0),
     .serdes_tx_hdr(qsfp_1_gt_txheader_0),
     .serdes_rx_data(qsfp_1_gt_rxdata_0),
     .serdes_rx_hdr(qsfp_1_gt_rxheader_0),
     .serdes_rx_bitslip(qsfp_1_gt_rxgearboxslip_0),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_1_rx_block_lock_0),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_1_tx_prbs31_enable_0),
+    .rx_prbs31_enable(qsfp_1_rx_prbs31_enable_0)
 );
 
 assign qsfp_1_tx_clk_1_int = clk_156mhz_int;
@@ -706,17 +762,25 @@ qsfp_1_phy_1_inst (
     .tx_rst(qsfp_1_tx_rst_1_int),
     .rx_clk(qsfp_1_rx_clk_1_int),
     .rx_rst(qsfp_1_rx_rst_1_int),
+    // XGMII interface
     .xgmii_txd(qsfp_1_txd_1_int),
     .xgmii_txc(qsfp_1_txc_1_int),
     .xgmii_rxd(qsfp_1_rxd_1_int),
     .xgmii_rxc(qsfp_1_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_1_gt_txdata_1),
     .serdes_tx_hdr(qsfp_1_gt_txheader_1),
     .serdes_rx_data(qsfp_1_gt_rxdata_1),
     .serdes_rx_hdr(qsfp_1_gt_rxheader_1),
     .serdes_rx_bitslip(qsfp_1_gt_rxgearboxslip_1),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_1_rx_block_lock_1),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_1_tx_prbs31_enable_1),
+    .rx_prbs31_enable(qsfp_1_rx_prbs31_enable_1)
 );
 
 assign qsfp_1_tx_clk_2_int = clk_156mhz_int;
@@ -741,17 +805,25 @@ qsfp_1_phy_2_inst (
     .tx_rst(qsfp_1_tx_rst_2_int),
     .rx_clk(qsfp_1_rx_clk_2_int),
     .rx_rst(qsfp_1_rx_rst_2_int),
+    // XGMII interface
     .xgmii_txd(qsfp_1_txd_2_int),
     .xgmii_txc(qsfp_1_txc_2_int),
     .xgmii_rxd(qsfp_1_rxd_2_int),
     .xgmii_rxc(qsfp_1_rxc_2_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_1_gt_txdata_2),
     .serdes_tx_hdr(qsfp_1_gt_txheader_2),
     .serdes_rx_data(qsfp_1_gt_rxdata_2),
     .serdes_rx_hdr(qsfp_1_gt_rxheader_2),
     .serdes_rx_bitslip(qsfp_1_gt_rxgearboxslip_2),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_1_rx_block_lock_2),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_1_tx_prbs31_enable_2),
+    .rx_prbs31_enable(qsfp_1_rx_prbs31_enable_2)
 );
 
 assign qsfp_1_tx_clk_3_int = clk_156mhz_int;
@@ -776,17 +848,25 @@ qsfp_1_phy_3_inst (
     .tx_rst(qsfp_1_tx_rst_3_int),
     .rx_clk(qsfp_1_rx_clk_3_int),
     .rx_rst(qsfp_1_rx_rst_3_int),
+    // XGMII interface
     .xgmii_txd(qsfp_1_txd_3_int),
     .xgmii_txc(qsfp_1_txc_3_int),
     .xgmii_rxd(qsfp_1_rxd_3_int),
     .xgmii_rxc(qsfp_1_rxc_3_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_1_gt_txdata_3),
     .serdes_tx_hdr(qsfp_1_gt_txheader_3),
     .serdes_rx_data(qsfp_1_gt_rxdata_3),
     .serdes_rx_hdr(qsfp_1_gt_rxheader_3),
     .serdes_rx_bitslip(qsfp_1_gt_rxgearboxslip_3),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_1_rx_block_lock_3),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_1_tx_prbs31_enable_3),
+    .rx_prbs31_enable(qsfp_1_rx_prbs31_enable_3)
 );
 
 //assign led = sw[0] ? {qsfp_1_rx_block_lock_4, qsfp_1_rx_block_lock_3, qsfp_1_rx_block_lock_2, qsfp_1_rx_block_lock_1, qsfp_0_rx_block_lock_4, qsfp_0_rx_block_lock_3, qsfp_0_rx_block_lock_2, qsfp_0_rx_block_lock_1} : led_int;

--- a/example/ADM_PCIE_9V3/fpga_10g/rtl/sync_signal.v
+++ b/example/ADM_PCIE_9V3/fpga_10g/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/ADM_PCIE_9V3/fpga_25g/rtl/fpga.v
+++ b/example/ADM_PCIE_9V3/fpga_25g/rtl/fpga.v
@@ -285,11 +285,27 @@ wire qsfp_0_rx_block_lock_0;
 wire qsfp_0_rx_block_lock_1;
 wire qsfp_0_rx_block_lock_2;
 wire qsfp_0_rx_block_lock_3;
+reg qsfp0_rx_prbs31_enable_0 = 1'b0;
+reg qsfp0_rx_prbs31_enable_1 = 1'b0;
+reg qsfp0_rx_prbs31_enable_2 = 1'b0;
+reg qsfp0_rx_prbs31_enable_3 = 1'b0;
+reg qsfp0_tx_prbs31_enable_0 = 1'b0;
+reg qsfp0_tx_prbs31_enable_1 = 1'b0;
+reg qsfp0_tx_prbs31_enable_2 = 1'b0;
+reg qsfp0_tx_prbs31_enable_3 = 1'b0;
 
 wire qsfp_1_rx_block_lock_0;
 wire qsfp_1_rx_block_lock_1;
 wire qsfp_1_rx_block_lock_2;
 wire qsfp_1_rx_block_lock_3;
+reg qsfp1_rx_prbs31_enable_0 = 1'b0;
+reg qsfp1_rx_prbs31_enable_1 = 1'b0;
+reg qsfp1_rx_prbs31_enable_2 = 1'b0;
+reg qsfp1_rx_prbs31_enable_3 = 1'b0;
+reg qsfp1_tx_prbs31_enable_0 = 1'b0;
+reg qsfp1_tx_prbs31_enable_1 = 1'b0;
+reg qsfp1_tx_prbs31_enable_2 = 1'b0;
+reg qsfp1_tx_prbs31_enable_3 = 1'b0;
 
 wire qsfp_0_mgt_refclk;
 wire qsfp_1_mgt_refclk;
@@ -534,17 +550,25 @@ qsfp_0_phy_0_inst (
     .tx_rst(qsfp_0_tx_rst_0_int),
     .rx_clk(qsfp_0_rx_clk_0_int),
     .rx_rst(qsfp_0_rx_rst_0_int),
+    // XGMII interface
     .xgmii_txd(qsfp_0_txd_0_int),
     .xgmii_txc(qsfp_0_txc_0_int),
     .xgmii_rxd(qsfp_0_rxd_0_int),
     .xgmii_rxc(qsfp_0_rxc_0_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_0_gt_txdata_0),
     .serdes_tx_hdr(qsfp_0_gt_txheader_0),
     .serdes_rx_data(qsfp_0_gt_rxdata_0),
     .serdes_rx_hdr(qsfp_0_gt_rxheader_0),
     .serdes_rx_bitslip(qsfp_0_gt_rxgearboxslip_0),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_0_rx_block_lock_0),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_0_tx_prbs31_enable_0),
+    .rx_prbs31_enable(qsfp_0_rx_prbs31_enable_0)
 );
 
 assign qsfp_0_tx_clk_1_int = clk_156mhz_int;
@@ -572,17 +596,25 @@ qsfp_0_phy_1_inst (
     .tx_rst(qsfp_0_tx_rst_1_int),
     .rx_clk(qsfp_0_rx_clk_1_int),
     .rx_rst(qsfp_0_rx_rst_1_int),
+    // XGMII interface
     .xgmii_txd(qsfp_0_txd_1_int),
     .xgmii_txc(qsfp_0_txc_1_int),
     .xgmii_rxd(qsfp_0_rxd_1_int),
     .xgmii_rxc(qsfp_0_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_0_gt_txdata_1),
     .serdes_tx_hdr(qsfp_0_gt_txheader_1),
     .serdes_rx_data(qsfp_0_gt_rxdata_1),
     .serdes_rx_hdr(qsfp_0_gt_rxheader_1),
     .serdes_rx_bitslip(qsfp_0_gt_rxgearboxslip_1),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_0_rx_block_lock_1),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_0_tx_prbs31_enable_1),
+    .rx_prbs31_enable(qsfp_0_rx_prbs31_enable_1)
 );
 
 assign qsfp_0_tx_clk_2_int = clk_156mhz_int;
@@ -610,17 +642,25 @@ qsfp_0_phy_2_inst (
     .tx_rst(qsfp_0_tx_rst_2_int),
     .rx_clk(qsfp_0_rx_clk_2_int),
     .rx_rst(qsfp_0_rx_rst_2_int),
+    // XGMII interface
     .xgmii_txd(qsfp_0_txd_2_int),
     .xgmii_txc(qsfp_0_txc_2_int),
     .xgmii_rxd(qsfp_0_rxd_2_int),
     .xgmii_rxc(qsfp_0_rxc_2_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_0_gt_txdata_2),
     .serdes_tx_hdr(qsfp_0_gt_txheader_2),
     .serdes_rx_data(qsfp_0_gt_rxdata_2),
     .serdes_rx_hdr(qsfp_0_gt_rxheader_2),
     .serdes_rx_bitslip(qsfp_0_gt_rxgearboxslip_2),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_0_rx_block_lock_2),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_0_tx_prbs31_enable_2),
+    .rx_prbs31_enable(qsfp_0_rx_prbs31_enable_2)
 );
 
 assign qsfp_0_tx_clk_3_int = clk_156mhz_int;
@@ -648,17 +688,25 @@ qsfp_0_phy_3_inst (
     .tx_rst(qsfp_0_tx_rst_3_int),
     .rx_clk(qsfp_0_rx_clk_3_int),
     .rx_rst(qsfp_0_rx_rst_3_int),
+    // XGMII interface
     .xgmii_txd(qsfp_0_txd_3_int),
     .xgmii_txc(qsfp_0_txc_3_int),
     .xgmii_rxd(qsfp_0_rxd_3_int),
     .xgmii_rxc(qsfp_0_rxc_3_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_0_gt_txdata_3),
     .serdes_tx_hdr(qsfp_0_gt_txheader_3),
     .serdes_rx_data(qsfp_0_gt_rxdata_3),
     .serdes_rx_hdr(qsfp_0_gt_rxheader_3),
     .serdes_rx_bitslip(qsfp_0_gt_rxgearboxslip_3),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_0_rx_block_lock_3),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_0_tx_prbs31_enable_3),
+    .rx_prbs31_enable(qsfp_0_rx_prbs31_enable_3)
 );
 
 assign qsfp_1_tx_clk_0_int = clk_156mhz_int;
@@ -686,17 +734,25 @@ qsfp_1_phy_0_inst (
     .tx_rst(qsfp_1_tx_rst_0_int),
     .rx_clk(qsfp_1_rx_clk_0_int),
     .rx_rst(qsfp_1_rx_rst_0_int),
+    // XGMII interface
     .xgmii_txd(qsfp_1_txd_0_int),
     .xgmii_txc(qsfp_1_txc_0_int),
     .xgmii_rxd(qsfp_1_rxd_0_int),
     .xgmii_rxc(qsfp_1_rxc_0_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_1_gt_txdata_0),
     .serdes_tx_hdr(qsfp_1_gt_txheader_0),
     .serdes_rx_data(qsfp_1_gt_rxdata_0),
     .serdes_rx_hdr(qsfp_1_gt_rxheader_0),
     .serdes_rx_bitslip(qsfp_1_gt_rxgearboxslip_0),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_1_rx_block_lock_0),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_1_tx_prbs31_enable_0),
+    .rx_prbs31_enable(qsfp_1_rx_prbs31_enable_0)
 );
 
 assign qsfp_1_tx_clk_1_int = clk_156mhz_int;
@@ -724,17 +780,25 @@ qsfp_1_phy_1_inst (
     .tx_rst(qsfp_1_tx_rst_1_int),
     .rx_clk(qsfp_1_rx_clk_1_int),
     .rx_rst(qsfp_1_rx_rst_1_int),
+    // XGMII interface
     .xgmii_txd(qsfp_1_txd_1_int),
     .xgmii_txc(qsfp_1_txc_1_int),
     .xgmii_rxd(qsfp_1_rxd_1_int),
     .xgmii_rxc(qsfp_1_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_1_gt_txdata_1),
     .serdes_tx_hdr(qsfp_1_gt_txheader_1),
     .serdes_rx_data(qsfp_1_gt_rxdata_1),
     .serdes_rx_hdr(qsfp_1_gt_rxheader_1),
     .serdes_rx_bitslip(qsfp_1_gt_rxgearboxslip_1),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_1_rx_block_lock_1),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_1_tx_prbs31_enable_1),
+    .rx_prbs31_enable(qsfp_1_rx_prbs31_enable_1)
 );
 
 assign qsfp_1_tx_clk_2_int = clk_156mhz_int;
@@ -762,17 +826,25 @@ qsfp_1_phy_2_inst (
     .tx_rst(qsfp_1_tx_rst_2_int),
     .rx_clk(qsfp_1_rx_clk_2_int),
     .rx_rst(qsfp_1_rx_rst_2_int),
+    // XGMII interface
     .xgmii_txd(qsfp_1_txd_2_int),
     .xgmii_txc(qsfp_1_txc_2_int),
     .xgmii_rxd(qsfp_1_rxd_2_int),
     .xgmii_rxc(qsfp_1_rxc_2_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_1_gt_txdata_2),
     .serdes_tx_hdr(qsfp_1_gt_txheader_2),
     .serdes_rx_data(qsfp_1_gt_rxdata_2),
     .serdes_rx_hdr(qsfp_1_gt_rxheader_2),
     .serdes_rx_bitslip(qsfp_1_gt_rxgearboxslip_2),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_1_rx_block_lock_2),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_1_tx_prbs31_enable_2),
+    .rx_prbs31_enable(qsfp_1_rx_prbs31_enable_2)
 );
 
 assign qsfp_1_tx_clk_3_int = clk_156mhz_int;
@@ -800,17 +872,25 @@ qsfp_1_phy_3_inst (
     .tx_rst(qsfp_1_tx_rst_3_int),
     .rx_clk(qsfp_1_rx_clk_3_int),
     .rx_rst(qsfp_1_rx_rst_3_int),
+    // XGMII interface
     .xgmii_txd(qsfp_1_txd_3_int),
     .xgmii_txc(qsfp_1_txc_3_int),
     .xgmii_rxd(qsfp_1_rxd_3_int),
     .xgmii_rxc(qsfp_1_rxc_3_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_1_gt_txdata_3),
     .serdes_tx_hdr(qsfp_1_gt_txheader_3),
     .serdes_rx_data(qsfp_1_gt_rxdata_3),
     .serdes_rx_hdr(qsfp_1_gt_rxheader_3),
     .serdes_rx_bitslip(qsfp_1_gt_rxgearboxslip_3),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_1_rx_block_lock_3),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_1_tx_prbs31_enable_3),
+    .rx_prbs31_enable(qsfp_1_rx_prbs31_enable_3)
 );
 
 //assign led = sw[0] ? {qsfp_1_rx_block_lock_4, qsfp_1_rx_block_lock_3, qsfp_1_rx_block_lock_2, qsfp_1_rx_block_lock_1, qsfp_0_rx_block_lock_4, qsfp_0_rx_block_lock_3, qsfp_0_rx_block_lock_2, qsfp_0_rx_block_lock_1} : led_int;

--- a/example/ADM_PCIE_9V3/fpga_25g/rtl/sync_signal.v
+++ b/example/ADM_PCIE_9V3/fpga_25g/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/ATLYS/fpga/rtl/sync_signal.v
+++ b/example/ATLYS/fpga/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/Arty/fpga/rtl/sync_signal.v
+++ b/example/Arty/fpga/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/DE5-Net/fpga/rtl/sync_signal.v
+++ b/example/DE5-Net/fpga/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/ExaNIC_X10/fpga/rtl/fpga.v
+++ b/example/ExaNIC_X10/fpga/rtl/fpga.v
@@ -196,7 +196,12 @@ wire [63:0] sfp_2_rxd_int;
 wire [7:0]  sfp_2_rxc_int;
 
 wire sfp_1_rx_block_lock;
+reg sfp_1_rx_prbs31_enable = 1'b0;
+reg sfp_1_tx_prbs31_enable = 1'b0;
+
 wire sfp_2_rx_block_lock;
+reg sfp_2_rx_prbs31_enable = 1'b0;
+reg sfp_2_tx_prbs31_enable = 1'b0;
 
 wire sfp_mgt_refclk;
 
@@ -405,17 +410,25 @@ sfp_1_phy_inst (
     .tx_rst(sfp_1_tx_rst_int),
     .rx_clk(sfp_1_rx_clk_int),
     .rx_rst(sfp_1_rx_rst_int),
+    // XGMII interface
     .xgmii_txd(sfp_1_txd_int),
     .xgmii_txc(sfp_1_txc_int),
     .xgmii_rxd(sfp_1_rxd_int),
     .xgmii_rxc(sfp_1_rxc_int),
+    // SERDES interface
     .serdes_tx_data(sfp_1_gt_txdata),
     .serdes_tx_hdr(sfp_1_gt_txheader),
     .serdes_rx_data(sfp_1_gt_rxdata),
     .serdes_rx_hdr(sfp_1_gt_rxheader),
     .serdes_rx_bitslip(sfp_1_gt_rxgearboxslip),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(sfp_1_rx_block_lock),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(sfp_1_tx_prbs31_enable),
+    .rx_prbs31_enable(sfp_1_rx_prbs31_enable)
 );
 
 assign sfp_2_tx_clk_int = clk_156mhz_int;
@@ -440,17 +453,25 @@ sfp_2_phy_inst (
     .tx_rst(sfp_2_tx_rst_int),
     .rx_clk(sfp_2_rx_clk_int),
     .rx_rst(sfp_2_rx_rst_int),
+    // XGMII interface
     .xgmii_txd(sfp_2_txd_int),
     .xgmii_txc(sfp_2_txc_int),
     .xgmii_rxd(sfp_2_rxd_int),
     .xgmii_rxc(sfp_2_rxc_int),
+    // SERDES interface
     .serdes_tx_data(sfp_2_gt_txdata),
     .serdes_tx_hdr(sfp_2_gt_txheader),
     .serdes_rx_data(sfp_2_gt_rxdata),
     .serdes_rx_hdr(sfp_2_gt_rxheader),
     .serdes_rx_bitslip(sfp_2_gt_rxgearboxslip),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(sfp_2_rx_block_lock),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(sfp_2_tx_prbs31_enable),
+    .rx_prbs31_enable(sfp_2_rx_prbs31_enable)
 );
 
 assign sfp_1_led[0] = sfp_1_rx_block_lock;

--- a/example/ExaNIC_X10/fpga/rtl/sync_signal.v
+++ b/example/ExaNIC_X10/fpga/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/ExaNIC_X25/fpga_10g/rtl/fpga.v
+++ b/example/ExaNIC_X25/fpga_10g/rtl/fpga.v
@@ -181,7 +181,12 @@ wire [63:0] sfp_2_rxd_int;
 wire [7:0]  sfp_2_rxc_int;
 
 wire sfp_1_rx_block_lock;
+reg sfp_1_tx_prbs31_enable = 1'b0;
+reg sfp_1_rx_prbs31_enable = 1'b0;
+
 wire sfp_2_rx_block_lock;
+reg sfp_2_tx_prbs31_enable = 1'b0;
+reg sfp_2_rx_prbs31_enable = 1'b0;
 
 wire sfp_gtpowergood;
 
@@ -386,17 +391,25 @@ sfp_1_phy_inst (
     .tx_rst(sfp_1_tx_rst_int),
     .rx_clk(sfp_1_rx_clk_int),
     .rx_rst(sfp_1_rx_rst_int),
+    // XGMII interface
     .xgmii_txd(sfp_1_txd_int),
     .xgmii_txc(sfp_1_txc_int),
     .xgmii_rxd(sfp_1_rxd_int),
     .xgmii_rxc(sfp_1_rxc_int),
+    // SERDES interface
     .serdes_tx_data(sfp_1_gt_txdata),
     .serdes_tx_hdr(sfp_1_gt_txheader),
     .serdes_rx_data(sfp_1_gt_rxdata),
     .serdes_rx_hdr(sfp_1_gt_rxheader),
     .serdes_rx_bitslip(sfp_1_gt_rxgearboxslip),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(sfp_1_rx_block_lock),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(sfp_1_tx_prbs31_enable),
+    .rx_prbs31_enable(sfp_1_rx_prbs31_enable)
 );
 
 assign sfp_2_tx_clk_int = clk_156mhz_int;
@@ -421,17 +434,25 @@ sfp_2_phy_inst (
     .tx_rst(sfp_2_tx_rst_int),
     .rx_clk(sfp_2_rx_clk_int),
     .rx_rst(sfp_2_rx_rst_int),
+    // XGMII interface
     .xgmii_txd(sfp_2_txd_int),
     .xgmii_txc(sfp_2_txc_int),
     .xgmii_rxd(sfp_2_rxd_int),
     .xgmii_rxc(sfp_2_rxc_int),
+    // SERDES interface
     .serdes_tx_data(sfp_2_gt_txdata),
     .serdes_tx_hdr(sfp_2_gt_txheader),
     .serdes_rx_data(sfp_2_gt_rxdata),
     .serdes_rx_hdr(sfp_2_gt_rxheader),
     .serdes_rx_bitslip(sfp_2_gt_rxgearboxslip),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(sfp_2_rx_block_lock),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(sfp_2_tx_prbs31_enable),
+    .rx_prbs31_enable(sfp_2_rx_prbs31_enable)
 );
 
 assign sfp_1_led[0] = sfp_1_rx_block_lock;

--- a/example/ExaNIC_X25/fpga_10g/rtl/sync_signal.v
+++ b/example/ExaNIC_X25/fpga_10g/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/HXT100G/fpga/rtl/sync_signal.v
+++ b/example/HXT100G/fpga/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/HXT100G/fpga_cxpt16/rtl/sync_signal.v
+++ b/example/HXT100G/fpga_cxpt16/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/KC705/fpga_gmii/rtl/sync_signal.v
+++ b/example/KC705/fpga_gmii/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/ML605/fpga_gmii/rtl/sync_signal.v
+++ b/example/ML605/fpga_gmii/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/ML605/fpga_rgmii/rtl/sync_signal.v
+++ b/example/ML605/fpga_rgmii/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/ML605/fpga_sgmii/rtl/sync_signal.v
+++ b/example/ML605/fpga_sgmii/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/NexysVideo/fpga/rtl/sync_signal.v
+++ b/example/NexysVideo/fpga/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/VCU108/fpga_10g/rtl/fpga.v
+++ b/example/VCU108/fpga_10g/rtl/fpga.v
@@ -305,6 +305,14 @@ wire qsfp_rx_block_lock_1;
 wire qsfp_rx_block_lock_2;
 wire qsfp_rx_block_lock_3;
 wire qsfp_rx_block_lock_4;
+reg qsfp_rx_prbs31_enable_1 = 1'b0;
+reg qsfp_rx_prbs31_enable_2 = 1'b0;
+reg qsfp_rx_prbs31_enable_3 = 1'b0;
+reg qsfp_rx_prbs31_enable_4 = 1'b0;
+reg qsfp_tx_prbs31_enable_1 = 1'b0;
+reg qsfp_tx_prbs31_enable_2 = 1'b0;
+reg qsfp_tx_prbs31_enable_3 = 1'b0;
+reg qsfp_tx_prbs31_enable_4 = 1'b0;
 
 wire qsfp_mgt_refclk_0;
 
@@ -505,17 +513,25 @@ qsfp_phy_1_inst (
     .tx_rst(qsfp_tx_rst_1_int),
     .rx_clk(qsfp_rx_clk_1_int),
     .rx_rst(qsfp_rx_rst_1_int),
+    // XGMII interface
     .xgmii_txd(qsfp_txd_1_int),
     .xgmii_txc(qsfp_txc_1_int),
     .xgmii_rxd(qsfp_rxd_1_int),
     .xgmii_rxc(qsfp_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_gt_txdata_1),
     .serdes_tx_hdr(qsfp_gt_txheader_1),
     .serdes_rx_data(qsfp_gt_rxdata_1),
     .serdes_rx_hdr(qsfp_gt_rxheader_1),
     .serdes_rx_bitslip(qsfp_gt_rxgearboxslip_1),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_rx_block_lock_1),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_tx_prbs31_enable_1),
+    .rx_prbs31_enable(qsfp_rx_prbs31_enable_1)
 );
 
 assign qsfp_tx_clk_2_int = clk_156mhz_int;
@@ -540,17 +556,25 @@ qsfp_phy_2_inst (
     .tx_rst(qsfp_tx_rst_2_int),
     .rx_clk(qsfp_rx_clk_2_int),
     .rx_rst(qsfp_rx_rst_2_int),
+    // XGMII interface
     .xgmii_txd(qsfp_txd_2_int),
     .xgmii_txc(qsfp_txc_2_int),
     .xgmii_rxd(qsfp_rxd_2_int),
     .xgmii_rxc(qsfp_rxc_2_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_gt_txdata_2),
     .serdes_tx_hdr(qsfp_gt_txheader_2),
     .serdes_rx_data(qsfp_gt_rxdata_2),
     .serdes_rx_hdr(qsfp_gt_rxheader_2),
     .serdes_rx_bitslip(qsfp_gt_rxgearboxslip_2),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_rx_block_lock_2),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_tx_prbs31_enable_2),
+    .rx_prbs31_enable(qsfp_rx_prbs31_enable_2)
 );
 
 assign qsfp_tx_clk_3_int = clk_156mhz_int;
@@ -575,17 +599,25 @@ qsfp_phy_3_inst (
     .tx_rst(qsfp_tx_rst_3_int),
     .rx_clk(qsfp_rx_clk_3_int),
     .rx_rst(qsfp_rx_rst_3_int),
+    // XGMII interface
     .xgmii_txd(qsfp_txd_3_int),
     .xgmii_txc(qsfp_txc_3_int),
     .xgmii_rxd(qsfp_rxd_3_int),
     .xgmii_rxc(qsfp_rxc_3_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_gt_txdata_3),
     .serdes_tx_hdr(qsfp_gt_txheader_3),
     .serdes_rx_data(qsfp_gt_rxdata_3),
     .serdes_rx_hdr(qsfp_gt_rxheader_3),
     .serdes_rx_bitslip(qsfp_gt_rxgearboxslip_3),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_rx_block_lock_3),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_tx_prbs31_enable_3),
+    .rx_prbs31_enable(qsfp_rx_prbs31_enable_3)
 );
 
 assign qsfp_tx_clk_4_int = clk_156mhz_int;
@@ -610,17 +642,25 @@ qsfp_phy_4_inst (
     .tx_rst(qsfp_tx_rst_4_int),
     .rx_clk(qsfp_rx_clk_4_int),
     .rx_rst(qsfp_rx_rst_4_int),
+    // XGMII interface
     .xgmii_txd(qsfp_txd_4_int),
     .xgmii_txc(qsfp_txc_4_int),
     .xgmii_rxd(qsfp_rxd_4_int),
     .xgmii_rxc(qsfp_rxc_4_int),
+    // SERDES interface
     .serdes_tx_data(qsfp_gt_txdata_4),
     .serdes_tx_hdr(qsfp_gt_txheader_4),
     .serdes_rx_data(qsfp_gt_rxdata_4),
     .serdes_rx_hdr(qsfp_gt_rxheader_4),
     .serdes_rx_bitslip(qsfp_gt_rxgearboxslip_4),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp_rx_block_lock_4),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp_tx_prbs31_enable_4),
+    .rx_prbs31_enable(qsfp_rx_prbs31_enable_4)
 );
 
 // // XGMII 10G PHY

--- a/example/VCU108/fpga_10g/rtl/sync_signal.v
+++ b/example/VCU108/fpga_10g/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/VCU108/fpga_1g/rtl/sync_signal.v
+++ b/example/VCU108/fpga_1g/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/VCU118/fpga_10g/rtl/fpga.v
+++ b/example/VCU118/fpga_10g/rtl/fpga.v
@@ -372,11 +372,27 @@ wire qsfp1_rx_block_lock_1;
 wire qsfp1_rx_block_lock_2;
 wire qsfp1_rx_block_lock_3;
 wire qsfp1_rx_block_lock_4;
+reg qsfp1_rx_prbs31_enable_1 = 1'b0;
+reg qsfp1_rx_prbs31_enable_2 = 1'b0;
+reg qsfp1_rx_prbs31_enable_3 = 1'b0;
+reg qsfp1_rx_prbs31_enable_4 = 1'b0;
+reg qsfp1_tx_prbs31_enable_1 = 1'b0;
+reg qsfp1_tx_prbs31_enable_2 = 1'b0;
+reg qsfp1_tx_prbs31_enable_3 = 1'b0;
+reg qsfp1_tx_prbs31_enable_4 = 1'b0;
 
 wire qsfp2_rx_block_lock_1;
 wire qsfp2_rx_block_lock_2;
 wire qsfp2_rx_block_lock_3;
 wire qsfp2_rx_block_lock_4;
+reg qsfp2_rx_prbs31_enable_1 = 1'b0;
+reg qsfp2_rx_prbs31_enable_2 = 1'b0;
+reg qsfp2_rx_prbs31_enable_3 = 1'b0;
+reg qsfp2_rx_prbs31_enable_4 = 1'b0;
+reg qsfp2_tx_prbs31_enable_1 = 1'b0;
+reg qsfp2_tx_prbs31_enable_2 = 1'b0;
+reg qsfp2_tx_prbs31_enable_3 = 1'b0;
+reg qsfp2_tx_prbs31_enable_4 = 1'b0;
 
 wire qsfp1_mgt_refclk_0;
 
@@ -609,17 +625,25 @@ qsfp1_phy_1_inst (
     .tx_rst(qsfp1_tx_rst_1_int),
     .rx_clk(qsfp1_rx_clk_1_int),
     .rx_rst(qsfp1_rx_rst_1_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_1_int),
     .xgmii_txc(qsfp1_txc_1_int),
     .xgmii_rxd(qsfp1_rxd_1_int),
     .xgmii_rxc(qsfp1_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_1),
     .serdes_tx_hdr(qsfp1_gt_txheader_1),
     .serdes_rx_data(qsfp1_gt_rxdata_1),
     .serdes_rx_hdr(qsfp1_gt_rxheader_1),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_1),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_1),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_1),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_1)
 );
 
 assign qsfp1_tx_clk_2_int = clk_156mhz_int;
@@ -644,17 +668,25 @@ qsfp1_phy_2_inst (
     .tx_rst(qsfp1_tx_rst_2_int),
     .rx_clk(qsfp1_rx_clk_2_int),
     .rx_rst(qsfp1_rx_rst_2_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_2_int),
     .xgmii_txc(qsfp1_txc_2_int),
     .xgmii_rxd(qsfp1_rxd_2_int),
     .xgmii_rxc(qsfp1_rxc_2_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_2),
     .serdes_tx_hdr(qsfp1_gt_txheader_2),
     .serdes_rx_data(qsfp1_gt_rxdata_2),
     .serdes_rx_hdr(qsfp1_gt_rxheader_2),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_2),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_2),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_2),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_2)
 );
 
 assign qsfp1_tx_clk_3_int = clk_156mhz_int;
@@ -679,17 +711,25 @@ qsfp1_phy_3_inst (
     .tx_rst(qsfp1_tx_rst_3_int),
     .rx_clk(qsfp1_rx_clk_3_int),
     .rx_rst(qsfp1_rx_rst_3_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_3_int),
     .xgmii_txc(qsfp1_txc_3_int),
     .xgmii_rxd(qsfp1_rxd_3_int),
     .xgmii_rxc(qsfp1_rxc_3_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_3),
     .serdes_tx_hdr(qsfp1_gt_txheader_3),
     .serdes_rx_data(qsfp1_gt_rxdata_3),
     .serdes_rx_hdr(qsfp1_gt_rxheader_3),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_3),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_3),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_3),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_3)
 );
 
 assign qsfp1_tx_clk_4_int = clk_156mhz_int;
@@ -714,17 +754,25 @@ qsfp1_phy_4_inst (
     .tx_rst(qsfp1_tx_rst_4_int),
     .rx_clk(qsfp1_rx_clk_4_int),
     .rx_rst(qsfp1_rx_rst_4_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_4_int),
     .xgmii_txc(qsfp1_txc_4_int),
     .xgmii_rxd(qsfp1_rxd_4_int),
     .xgmii_rxc(qsfp1_rxc_4_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_4),
     .serdes_tx_hdr(qsfp1_gt_txheader_4),
     .serdes_rx_data(qsfp1_gt_rxdata_4),
     .serdes_rx_hdr(qsfp1_gt_rxheader_4),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_4),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_4),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_4),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_4)
 );
 
 assign qsfp2_tx_clk_1_int = clk_156mhz_int;
@@ -749,17 +797,25 @@ qsfp2_phy_1_inst (
     .tx_rst(qsfp2_tx_rst_1_int),
     .rx_clk(qsfp2_rx_clk_1_int),
     .rx_rst(qsfp2_rx_rst_1_int),
+    // XGMII interface
     .xgmii_txd(qsfp2_txd_1_int),
     .xgmii_txc(qsfp2_txc_1_int),
     .xgmii_rxd(qsfp2_rxd_1_int),
     .xgmii_rxc(qsfp2_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp2_gt_txdata_1),
     .serdes_tx_hdr(qsfp2_gt_txheader_1),
     .serdes_rx_data(qsfp2_gt_rxdata_1),
     .serdes_rx_hdr(qsfp2_gt_rxheader_1),
     .serdes_rx_bitslip(qsfp2_gt_rxgearboxslip_1),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp2_rx_block_lock_1),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp2_tx_prbs31_enable_1),
+    .rx_prbs31_enable(qsfp2_rx_prbs31_enable_1)
 );
 
 assign qsfp2_tx_clk_2_int = clk_156mhz_int;
@@ -784,17 +840,25 @@ qsfp2_phy_2_inst (
     .tx_rst(qsfp2_tx_rst_2_int),
     .rx_clk(qsfp2_rx_clk_2_int),
     .rx_rst(qsfp2_rx_rst_2_int),
+    // XGMII interface
     .xgmii_txd(qsfp2_txd_2_int),
     .xgmii_txc(qsfp2_txc_2_int),
     .xgmii_rxd(qsfp2_rxd_2_int),
     .xgmii_rxc(qsfp2_rxc_2_int),
+    // SERDES interface
     .serdes_tx_data(qsfp2_gt_txdata_2),
     .serdes_tx_hdr(qsfp2_gt_txheader_2),
     .serdes_rx_data(qsfp2_gt_rxdata_2),
     .serdes_rx_hdr(qsfp2_gt_rxheader_2),
     .serdes_rx_bitslip(qsfp2_gt_rxgearboxslip_2),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp2_rx_block_lock_2),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp2_tx_prbs31_enable_2),
+    .rx_prbs31_enable(qsfp2_rx_prbs31_enable_2)
 );
 
 assign qsfp2_tx_clk_3_int = clk_156mhz_int;
@@ -819,17 +883,25 @@ qsfp2_phy_3_inst (
     .tx_rst(qsfp2_tx_rst_3_int),
     .rx_clk(qsfp2_rx_clk_3_int),
     .rx_rst(qsfp2_rx_rst_3_int),
+    // XGMII interface
     .xgmii_txd(qsfp2_txd_3_int),
     .xgmii_txc(qsfp2_txc_3_int),
     .xgmii_rxd(qsfp2_rxd_3_int),
     .xgmii_rxc(qsfp2_rxc_3_int),
+    // SERDES interface
     .serdes_tx_data(qsfp2_gt_txdata_3),
     .serdes_tx_hdr(qsfp2_gt_txheader_3),
     .serdes_rx_data(qsfp2_gt_rxdata_3),
     .serdes_rx_hdr(qsfp2_gt_rxheader_3),
     .serdes_rx_bitslip(qsfp2_gt_rxgearboxslip_3),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp2_rx_block_lock_3),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp2_tx_prbs31_enable_3),
+    .rx_prbs31_enable(qsfp2_rx_prbs31_enable_3)
 );
 
 assign qsfp2_tx_clk_4_int = clk_156mhz_int;
@@ -854,17 +926,25 @@ qsfp2_phy_4_inst (
     .tx_rst(qsfp2_tx_rst_4_int),
     .rx_clk(qsfp2_rx_clk_4_int),
     .rx_rst(qsfp2_rx_rst_4_int),
+    // XGMII interface
     .xgmii_txd(qsfp2_txd_4_int),
     .xgmii_txc(qsfp2_txc_4_int),
     .xgmii_rxd(qsfp2_rxd_4_int),
     .xgmii_rxc(qsfp2_rxc_4_int),
+    // SERDES interface
     .serdes_tx_data(qsfp2_gt_txdata_4),
     .serdes_tx_hdr(qsfp2_gt_txheader_4),
     .serdes_rx_data(qsfp2_gt_rxdata_4),
     .serdes_rx_hdr(qsfp2_gt_rxheader_4),
     .serdes_rx_bitslip(qsfp2_gt_rxgearboxslip_4),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp2_rx_block_lock_4),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp2_tx_prbs31_enable_4),
+    .rx_prbs31_enable(qsfp2_rx_prbs31_enable_4)
 );
 
 // SGMII interface to PHY

--- a/example/VCU118/fpga_10g/rtl/sync_signal.v
+++ b/example/VCU118/fpga_10g/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/VCU118/fpga_1g/rtl/sync_signal.v
+++ b/example/VCU118/fpga_1g/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/VCU118/fpga_25g/rtl/fpga.v
+++ b/example/VCU118/fpga_25g/rtl/fpga.v
@@ -372,11 +372,27 @@ wire qsfp1_rx_block_lock_1;
 wire qsfp1_rx_block_lock_2;
 wire qsfp1_rx_block_lock_3;
 wire qsfp1_rx_block_lock_4;
+reg qsfp1_rx_prbs31_enable_1 = 1'b0;
+reg qsfp1_rx_prbs31_enable_2 = 1'b0;
+reg qsfp1_rx_prbs31_enable_3 = 1'b0;
+reg qsfp1_rx_prbs31_enable_4 = 1'b0;
+reg qsfp1_tx_prbs31_enable_1 = 1'b0;
+reg qsfp1_tx_prbs31_enable_2 = 1'b0;
+reg qsfp1_tx_prbs31_enable_3 = 1'b0;
+reg qsfp1_tx_prbs31_enable_4 = 1'b0;
 
 wire qsfp2_rx_block_lock_1;
 wire qsfp2_rx_block_lock_2;
 wire qsfp2_rx_block_lock_3;
 wire qsfp2_rx_block_lock_4;
+reg qsfp2_rx_prbs31_enable_1 = 1'b0;
+reg qsfp2_rx_prbs31_enable_2 = 1'b0;
+reg qsfp2_rx_prbs31_enable_3 = 1'b0;
+reg qsfp2_rx_prbs31_enable_4 = 1'b0;
+reg qsfp2_tx_prbs31_enable_1 = 1'b0;
+reg qsfp2_tx_prbs31_enable_2 = 1'b0;
+reg qsfp2_tx_prbs31_enable_3 = 1'b0;
+reg qsfp2_tx_prbs31_enable_4 = 1'b0;
 
 wire qsfp1_mgt_refclk_0;
 
@@ -612,17 +628,25 @@ qsfp1_phy_1_inst (
     .tx_rst(qsfp1_tx_rst_1_int),
     .rx_clk(qsfp1_rx_clk_1_int),
     .rx_rst(qsfp1_rx_rst_1_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_1_int),
     .xgmii_txc(qsfp1_txc_1_int),
     .xgmii_rxd(qsfp1_rxd_1_int),
     .xgmii_rxc(qsfp1_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_1),
     .serdes_tx_hdr(qsfp1_gt_txheader_1),
     .serdes_rx_data(qsfp1_gt_rxdata_1),
     .serdes_rx_hdr(qsfp1_gt_rxheader_1),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_1),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_1),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_1),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_1)
 );
 
 assign qsfp1_tx_clk_2_int = clk_156mhz_int;
@@ -650,17 +674,25 @@ qsfp1_phy_2_inst (
     .tx_rst(qsfp1_tx_rst_2_int),
     .rx_clk(qsfp1_rx_clk_2_int),
     .rx_rst(qsfp1_rx_rst_2_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_2_int),
     .xgmii_txc(qsfp1_txc_2_int),
     .xgmii_rxd(qsfp1_rxd_2_int),
     .xgmii_rxc(qsfp1_rxc_2_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_2),
     .serdes_tx_hdr(qsfp1_gt_txheader_2),
     .serdes_rx_data(qsfp1_gt_rxdata_2),
     .serdes_rx_hdr(qsfp1_gt_rxheader_2),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_2),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_2),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_2),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_2)
 );
 
 assign qsfp1_tx_clk_3_int = clk_156mhz_int;
@@ -688,17 +720,25 @@ qsfp1_phy_3_inst (
     .tx_rst(qsfp1_tx_rst_3_int),
     .rx_clk(qsfp1_rx_clk_3_int),
     .rx_rst(qsfp1_rx_rst_3_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_3_int),
     .xgmii_txc(qsfp1_txc_3_int),
     .xgmii_rxd(qsfp1_rxd_3_int),
     .xgmii_rxc(qsfp1_rxc_3_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_3),
     .serdes_tx_hdr(qsfp1_gt_txheader_3),
     .serdes_rx_data(qsfp1_gt_rxdata_3),
     .serdes_rx_hdr(qsfp1_gt_rxheader_3),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_3),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_3),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_3),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_3)
 );
 
 assign qsfp1_tx_clk_4_int = clk_156mhz_int;
@@ -726,17 +766,25 @@ qsfp1_phy_4_inst (
     .tx_rst(qsfp1_tx_rst_4_int),
     .rx_clk(qsfp1_rx_clk_4_int),
     .rx_rst(qsfp1_rx_rst_4_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_4_int),
     .xgmii_txc(qsfp1_txc_4_int),
     .xgmii_rxd(qsfp1_rxd_4_int),
     .xgmii_rxc(qsfp1_rxc_4_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_4),
     .serdes_tx_hdr(qsfp1_gt_txheader_4),
     .serdes_rx_data(qsfp1_gt_rxdata_4),
     .serdes_rx_hdr(qsfp1_gt_rxheader_4),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_4),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_4),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_4),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_4)
 );
 
 assign qsfp2_tx_clk_1_int = clk_156mhz_int;
@@ -764,17 +812,25 @@ qsfp2_phy_1_inst (
     .tx_rst(qsfp2_tx_rst_1_int),
     .rx_clk(qsfp2_rx_clk_1_int),
     .rx_rst(qsfp2_rx_rst_1_int),
+    // XGMII interface
     .xgmii_txd(qsfp2_txd_1_int),
     .xgmii_txc(qsfp2_txc_1_int),
     .xgmii_rxd(qsfp2_rxd_1_int),
     .xgmii_rxc(qsfp2_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp2_gt_txdata_1),
     .serdes_tx_hdr(qsfp2_gt_txheader_1),
     .serdes_rx_data(qsfp2_gt_rxdata_1),
     .serdes_rx_hdr(qsfp2_gt_rxheader_1),
     .serdes_rx_bitslip(qsfp2_gt_rxgearboxslip_1),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp2_rx_block_lock_1),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp2_tx_prbs31_enable_1),
+    .rx_prbs31_enable(qsfp2_rx_prbs31_enable_1)
 );
 
 assign qsfp2_tx_clk_2_int = clk_156mhz_int;
@@ -802,17 +858,25 @@ qsfp2_phy_2_inst (
     .tx_rst(qsfp2_tx_rst_2_int),
     .rx_clk(qsfp2_rx_clk_2_int),
     .rx_rst(qsfp2_rx_rst_2_int),
+    // XGMII interface
     .xgmii_txd(qsfp2_txd_2_int),
     .xgmii_txc(qsfp2_txc_2_int),
     .xgmii_rxd(qsfp2_rxd_2_int),
     .xgmii_rxc(qsfp2_rxc_2_int),
+    // SERDES interface
     .serdes_tx_data(qsfp2_gt_txdata_2),
     .serdes_tx_hdr(qsfp2_gt_txheader_2),
     .serdes_rx_data(qsfp2_gt_rxdata_2),
     .serdes_rx_hdr(qsfp2_gt_rxheader_2),
     .serdes_rx_bitslip(qsfp2_gt_rxgearboxslip_2),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp2_rx_block_lock_2),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp2_tx_prbs31_enable_2),
+    .rx_prbs31_enable(qsfp2_rx_prbs31_enable_2)
 );
 
 assign qsfp2_tx_clk_3_int = clk_156mhz_int;
@@ -840,17 +904,25 @@ qsfp2_phy_3_inst (
     .tx_rst(qsfp2_tx_rst_3_int),
     .rx_clk(qsfp2_rx_clk_3_int),
     .rx_rst(qsfp2_rx_rst_3_int),
+    // XGMII interface
     .xgmii_txd(qsfp2_txd_3_int),
     .xgmii_txc(qsfp2_txc_3_int),
     .xgmii_rxd(qsfp2_rxd_3_int),
     .xgmii_rxc(qsfp2_rxc_3_int),
+    // SERDES interface
     .serdes_tx_data(qsfp2_gt_txdata_3),
     .serdes_tx_hdr(qsfp2_gt_txheader_3),
     .serdes_rx_data(qsfp2_gt_rxdata_3),
     .serdes_rx_hdr(qsfp2_gt_rxheader_3),
     .serdes_rx_bitslip(qsfp2_gt_rxgearboxslip_3),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp2_rx_block_lock_3),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp2_tx_prbs31_enable_3),
+    .rx_prbs31_enable(qsfp2_rx_prbs31_enable_3)
 );
 
 assign qsfp2_tx_clk_4_int = clk_156mhz_int;
@@ -878,17 +950,25 @@ qsfp2_phy_4_inst (
     .tx_rst(qsfp2_tx_rst_4_int),
     .rx_clk(qsfp2_rx_clk_4_int),
     .rx_rst(qsfp2_rx_rst_4_int),
+    // XGMII interface
     .xgmii_txd(qsfp2_txd_4_int),
     .xgmii_txc(qsfp2_txc_4_int),
     .xgmii_rxd(qsfp2_rxd_4_int),
     .xgmii_rxc(qsfp2_rxc_4_int),
+    // SERDES interface
     .serdes_tx_data(qsfp2_gt_txdata_4),
     .serdes_tx_hdr(qsfp2_gt_txheader_4),
     .serdes_rx_data(qsfp2_gt_rxdata_4),
     .serdes_rx_hdr(qsfp2_gt_rxheader_4),
     .serdes_rx_bitslip(qsfp2_gt_rxgearboxslip_4),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp2_rx_block_lock_4),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp2_tx_prbs31_enable_4),
+    .rx_prbs31_enable(qsfp2_rx_prbs31_enable_4)
 );
 
 // SGMII interface to PHY

--- a/example/VCU118/fpga_25g/rtl/sync_signal.v
+++ b/example/VCU118/fpga_25g/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/example/VCU1525/fpga_10g/rtl/fpga.v
+++ b/example/VCU1525/fpga_10g/rtl/fpga.v
@@ -387,11 +387,27 @@ wire qsfp0_rx_block_lock_1;
 wire qsfp0_rx_block_lock_2;
 wire qsfp0_rx_block_lock_3;
 wire qsfp0_rx_block_lock_4;
+reg qsfp0_rx_prbs31_enable_1 = 1'b0;
+reg qsfp0_rx_prbs31_enable_2 = 1'b0;
+reg qsfp0_rx_prbs31_enable_3 = 1'b0;
+reg qsfp0_rx_prbs31_enable_4 = 1'b0;
+reg qsfp0_tx_prbs31_enable_1 = 1'b0;
+reg qsfp0_tx_prbs31_enable_2 = 1'b0;
+reg qsfp0_tx_prbs31_enable_3 = 1'b0;
+reg qsfp0_tx_prbs31_enable_4 = 1'b0;
 
 wire qsfp1_rx_block_lock_1;
 wire qsfp1_rx_block_lock_2;
 wire qsfp1_rx_block_lock_3;
 wire qsfp1_rx_block_lock_4;
+reg qsfp1_rx_prbs31_enable_1 = 1'b0;
+reg qsfp1_rx_prbs31_enable_2 = 1'b0;
+reg qsfp1_rx_prbs31_enable_3 = 1'b0;
+reg qsfp1_rx_prbs31_enable_4 = 1'b0;
+reg qsfp1_tx_prbs31_enable_1 = 1'b0;
+reg qsfp1_tx_prbs31_enable_2 = 1'b0;
+reg qsfp1_tx_prbs31_enable_3 = 1'b0;
+reg qsfp1_tx_prbs31_enable_4 = 1'b0;
 
 wire [7:0] qsfp_gtpowergood;
 
@@ -639,17 +655,25 @@ qsfp0_phy_1_inst (
     .tx_rst(qsfp0_tx_rst_1_int),
     .rx_clk(qsfp0_rx_clk_1_int),
     .rx_rst(qsfp0_rx_rst_1_int),
+    // XGMII interface
     .xgmii_txd(qsfp0_txd_1_int),
     .xgmii_txc(qsfp0_txc_1_int),
     .xgmii_rxd(qsfp0_rxd_1_int),
     .xgmii_rxc(qsfp0_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp0_gt_txdata_1),
     .serdes_tx_hdr(qsfp0_gt_txheader_1),
     .serdes_rx_data(qsfp0_gt_rxdata_1),
     .serdes_rx_hdr(qsfp0_gt_rxheader_1),
     .serdes_rx_bitslip(qsfp0_gt_rxgearboxslip_1),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp0_rx_block_lock_1),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp0_tx_prbs31_enable_1),
+    .rx_prbs31_enable(qsfp0_rx_prbs31_enable_1)
 );
 
 assign qsfp0_tx_clk_2_int = clk_156mhz_int;
@@ -674,17 +698,25 @@ qsfp0_phy_2_inst (
     .tx_rst(qsfp0_tx_rst_2_int),
     .rx_clk(qsfp0_rx_clk_2_int),
     .rx_rst(qsfp0_rx_rst_2_int),
+    // XGMII interface
     .xgmii_txd(qsfp0_txd_2_int),
     .xgmii_txc(qsfp0_txc_2_int),
     .xgmii_rxd(qsfp0_rxd_2_int),
     .xgmii_rxc(qsfp0_rxc_2_int),
+    // SERDES interface
     .serdes_tx_data(qsfp0_gt_txdata_2),
     .serdes_tx_hdr(qsfp0_gt_txheader_2),
     .serdes_rx_data(qsfp0_gt_rxdata_2),
     .serdes_rx_hdr(qsfp0_gt_rxheader_2),
     .serdes_rx_bitslip(qsfp0_gt_rxgearboxslip_2),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp0_rx_block_lock_2),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp0_tx_prbs31_enable_2),
+    .rx_prbs31_enable(qsfp0_rx_prbs31_enable_2)
 );
 
 assign qsfp0_tx_clk_3_int = clk_156mhz_int;
@@ -709,17 +741,25 @@ qsfp0_phy_3_inst (
     .tx_rst(qsfp0_tx_rst_3_int),
     .rx_clk(qsfp0_rx_clk_3_int),
     .rx_rst(qsfp0_rx_rst_3_int),
+    // XGMII interface
     .xgmii_txd(qsfp0_txd_3_int),
     .xgmii_txc(qsfp0_txc_3_int),
     .xgmii_rxd(qsfp0_rxd_3_int),
     .xgmii_rxc(qsfp0_rxc_3_int),
+    // SERDES interface
     .serdes_tx_data(qsfp0_gt_txdata_3),
     .serdes_tx_hdr(qsfp0_gt_txheader_3),
     .serdes_rx_data(qsfp0_gt_rxdata_3),
     .serdes_rx_hdr(qsfp0_gt_rxheader_3),
     .serdes_rx_bitslip(qsfp0_gt_rxgearboxslip_3),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp0_rx_block_lock_3),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp0_tx_prbs31_enable_3),
+    .rx_prbs31_enable(qsfp0_rx_prbs31_enable_3)
 );
 
 assign qsfp0_tx_clk_4_int = clk_156mhz_int;
@@ -744,17 +784,26 @@ qsfp0_phy_4_inst (
     .tx_rst(qsfp0_tx_rst_4_int),
     .rx_clk(qsfp0_rx_clk_4_int),
     .rx_rst(qsfp0_rx_rst_4_int),
+    // XGMII interface
     .xgmii_txd(qsfp0_txd_4_int),
     .xgmii_txc(qsfp0_txc_4_int),
     .xgmii_rxd(qsfp0_rxd_4_int),
     .xgmii_rxc(qsfp0_rxc_4_int),
+    .xgmii_rxc(qsfp1_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp0_gt_txdata_4),
     .serdes_tx_hdr(qsfp0_gt_txheader_4),
     .serdes_rx_data(qsfp0_gt_rxdata_4),
     .serdes_rx_hdr(qsfp0_gt_rxheader_4),
     .serdes_rx_bitslip(qsfp0_gt_rxgearboxslip_4),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp0_rx_block_lock_4),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp0_tx_prbs31_enable_4),
+    .rx_prbs31_enable(qsfp0_rx_prbs31_enable_4)
 );
 
 assign qsfp1_tx_clk_1_int = clk_156mhz_int;
@@ -779,17 +828,25 @@ qsfp1_phy_1_inst (
     .tx_rst(qsfp1_tx_rst_1_int),
     .rx_clk(qsfp1_rx_clk_1_int),
     .rx_rst(qsfp1_rx_rst_1_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_1_int),
     .xgmii_txc(qsfp1_txc_1_int),
     .xgmii_rxd(qsfp1_rxd_1_int),
     .xgmii_rxc(qsfp1_rxc_1_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_1),
     .serdes_tx_hdr(qsfp1_gt_txheader_1),
     .serdes_rx_data(qsfp1_gt_rxdata_1),
     .serdes_rx_hdr(qsfp1_gt_rxheader_1),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_1),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_1),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_1),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_1)
 );
 
 assign qsfp1_tx_clk_2_int = clk_156mhz_int;
@@ -814,17 +871,25 @@ qsfp1_phy_2_inst (
     .tx_rst(qsfp1_tx_rst_2_int),
     .rx_clk(qsfp1_rx_clk_2_int),
     .rx_rst(qsfp1_rx_rst_2_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_2_int),
     .xgmii_txc(qsfp1_txc_2_int),
     .xgmii_rxd(qsfp1_rxd_2_int),
     .xgmii_rxc(qsfp1_rxc_2_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_2),
     .serdes_tx_hdr(qsfp1_gt_txheader_2),
     .serdes_rx_data(qsfp1_gt_rxdata_2),
     .serdes_rx_hdr(qsfp1_gt_rxheader_2),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_2),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_2),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_2),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_2)
 );
 
 assign qsfp1_tx_clk_3_int = clk_156mhz_int;
@@ -849,17 +914,25 @@ qsfp1_phy_3_inst (
     .tx_rst(qsfp1_tx_rst_3_int),
     .rx_clk(qsfp1_rx_clk_3_int),
     .rx_rst(qsfp1_rx_rst_3_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_3_int),
     .xgmii_txc(qsfp1_txc_3_int),
     .xgmii_rxd(qsfp1_rxd_3_int),
     .xgmii_rxc(qsfp1_rxc_3_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_3),
     .serdes_tx_hdr(qsfp1_gt_txheader_3),
     .serdes_rx_data(qsfp1_gt_rxdata_3),
     .serdes_rx_hdr(qsfp1_gt_rxheader_3),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_3),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_3),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_3),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_3)
 );
 
 assign qsfp1_tx_clk_4_int = clk_156mhz_int;
@@ -884,17 +957,25 @@ qsfp1_phy_4_inst (
     .tx_rst(qsfp1_tx_rst_4_int),
     .rx_clk(qsfp1_rx_clk_4_int),
     .rx_rst(qsfp1_rx_rst_4_int),
+    // XGMII interface
     .xgmii_txd(qsfp1_txd_4_int),
     .xgmii_txc(qsfp1_txc_4_int),
     .xgmii_rxd(qsfp1_rxd_4_int),
     .xgmii_rxc(qsfp1_rxc_4_int),
+    // SERDES interface
     .serdes_tx_data(qsfp1_gt_txdata_4),
     .serdes_tx_hdr(qsfp1_gt_txheader_4),
     .serdes_rx_data(qsfp1_gt_rxdata_4),
     .serdes_rx_hdr(qsfp1_gt_rxheader_4),
     .serdes_rx_bitslip(qsfp1_gt_rxgearboxslip_4),
+    // Status
+    .rx_error_count(),
+    .rx_bad_block(),
     .rx_block_lock(qsfp1_rx_block_lock_4),
-    .rx_high_ber()
+    .rx_high_ber(),
+    // Configuration
+    .tx_prbs31_enable(qsfp1_tx_prbs31_enable_4),
+    .rx_prbs31_enable(qsfp1_rx_prbs31_enable_4)
 );
 
 fpga_core

--- a/example/VCU1525/fpga_10g/rtl/sync_signal.v
+++ b/example/VCU1525/fpga_10g/rtl/sync_signal.v
@@ -27,7 +27,7 @@ THE SOFTWARE.
 `timescale 1 ns / 1 ps
 
 /*
- * Synchronizes an asyncronous signal to a given clock by using a pipeline of
+ * Synchronizes an asynchronous signal to a given clock by using a pipeline of
  * two registers.
  */
 module sync_signal #(

--- a/rtl/arp_eth_rx.v
+++ b/rtl/arp_eth_rx.v
@@ -84,11 +84,11 @@ module arp_eth_rx #
     output wire                   error_invalid_header
 );
 
-parameter CYCLE_COUNT = (28+KEEP_WIDTH-1)/KEEP_WIDTH;
+localparam CYCLE_COUNT = (28+KEEP_WIDTH-1)/KEEP_WIDTH;
 
 parameter PTR_WIDTH = $clog2(CYCLE_COUNT);
 
-parameter OFFSET = 28 % KEEP_WIDTH;
+localparam OFFSET = 28 % KEEP_WIDTH;
 
 // bus width assertions
 initial begin

--- a/rtl/arp_eth_tx.v
+++ b/rtl/arp_eth_tx.v
@@ -80,11 +80,11 @@ module arp_eth_tx #
     output wire                   busy
 );
 
-parameter CYCLE_COUNT = (28+KEEP_WIDTH-1)/KEEP_WIDTH;
+localparam CYCLE_COUNT = (28+KEEP_WIDTH-1)/KEEP_WIDTH;
 
 parameter PTR_WIDTH = $clog2(CYCLE_COUNT);
 
-parameter OFFSET = 28 % KEEP_WIDTH;
+localparam OFFSET = 28 % KEEP_WIDTH;
 
 // bus width assertions
 initial begin

--- a/rtl/eth_axis_rx.v
+++ b/rtl/eth_axis_rx.v
@@ -75,11 +75,11 @@ module eth_axis_rx #
     output wire                  error_header_early_termination
 );
 
-parameter CYCLE_COUNT = (14+KEEP_WIDTH-1)/KEEP_WIDTH;
+localparam CYCLE_COUNT = (14+KEEP_WIDTH-1)/KEEP_WIDTH;
 
 parameter PTR_WIDTH = $clog2(CYCLE_COUNT);
 
-parameter OFFSET = 14 % KEEP_WIDTH;
+localparam OFFSET = 14 % KEEP_WIDTH;
 
 // bus width assertions
 initial begin

--- a/rtl/eth_axis_tx.v
+++ b/rtl/eth_axis_tx.v
@@ -74,11 +74,11 @@ module eth_axis_tx #
     output wire                  busy
 );
 
-parameter CYCLE_COUNT = (14+KEEP_WIDTH-1)/KEEP_WIDTH;
+localparam CYCLE_COUNT = (14+KEEP_WIDTH-1)/KEEP_WIDTH;
 
 parameter PTR_WIDTH = $clog2(CYCLE_COUNT);
 
-parameter OFFSET = 14 % KEEP_WIDTH;
+localparam OFFSET = 14 % KEEP_WIDTH;
 
 // bus width assertions
 initial begin

--- a/rtl/eth_mac_10g_fifo.v
+++ b/rtl/eth_mac_10g_fifo.v
@@ -143,7 +143,7 @@ module eth_mac_10g_fifo #
     input  wire [7:0]                 ifg_delay
 );
 
-parameter KEEP_WIDTH = DATA_WIDTH/8;
+localparam KEEP_WIDTH = DATA_WIDTH/8;
 
 localparam TX_USER_WIDTH = (TX_PTP_TS_ENABLE && TX_PTP_TAG_ENABLE ? PTP_TAG_WIDTH : 0) + 1;
 localparam RX_USER_WIDTH = (RX_PTP_TS_ENABLE ? PTP_TS_WIDTH : 0) + 1;

--- a/rtl/eth_mac_10g_fifo.v
+++ b/rtl/eth_mac_10g_fifo.v
@@ -568,7 +568,9 @@ eth_mac_10g_inst (
     .tx_axis_ptp_ts_tag(tx_axis_ptp_ts_tag),
     .tx_axis_ptp_ts_valid(tx_axis_ptp_ts_valid),
 
+    .tx_start_packet(),
     .tx_error_underflow(tx_error_underflow_int),
+    .rx_start_packet(),
     .rx_error_bad_frame(rx_error_bad_frame_int),
     .rx_error_bad_fcs(rx_error_bad_fcs_int),
 

--- a/rtl/eth_mac_phy_10g_fifo.v
+++ b/rtl/eth_mac_phy_10g_fifo.v
@@ -156,7 +156,7 @@ module eth_mac_phy_10g_fifo #
     input  wire                       rx_prbs31_enable
 );
 
-parameter KEEP_WIDTH = DATA_WIDTH/8;
+localparam KEEP_WIDTH = DATA_WIDTH/8;
 
 localparam TX_USER_WIDTH = (TX_PTP_TS_ENABLE && TX_PTP_TAG_ENABLE ? PTP_TAG_WIDTH : 0) + 1;
 localparam RX_USER_WIDTH = (RX_PTP_TS_ENABLE ? PTP_TS_WIDTH : 0) + 1;

--- a/rtl/lfsr.v
+++ b/rtl/lfsr.v
@@ -360,10 +360,10 @@ end
 
 `ifdef SIMULATION
 // "AUTO" style is "REDUCTION" for faster simulation
-parameter STYLE_INT = (STYLE == "AUTO") ? "REDUCTION" : STYLE;
+localparam STYLE_INT = (STYLE == "AUTO") ? "REDUCTION" : STYLE;
 `else
 // "AUTO" style is "LOOP" for better synthesis result
-parameter STYLE_INT = (STYLE == "AUTO") ? "LOOP" : STYLE;
+localparam STYLE_INT = (STYLE == "AUTO") ? "LOOP" : STYLE;
 `endif
 
 genvar n;

--- a/rtl/ptp_clock_cdc.v
+++ b/rtl/ptp_clock_cdc.v
@@ -74,13 +74,13 @@ initial begin
     end
 end
 
-parameter TS_NS_WIDTH = TS_WIDTH == 96 ? 30 : 48;
+localparam TS_NS_WIDTH = TS_WIDTH == 96 ? 30 : 48;
 
-parameter FIFO_ADDR_WIDTH = LOG_FIFO_DEPTH+1;
-parameter LOG_AVG = 6;
-parameter LOG_AVG_SCALE = LOG_AVG+8;
-parameter LOG_AVG_SYNC_RATE = LOG_RATE;
-parameter WR_PERIOD = ((((INPUT_PERIOD_NS << 16) + INPUT_PERIOD_FNS) + 64'd0) << 16) / ((OUTPUT_PERIOD_NS << 16) + OUTPUT_PERIOD_FNS) / 2**(LOG_RATE+1);
+localparam FIFO_ADDR_WIDTH = LOG_FIFO_DEPTH+1;
+localparam LOG_AVG = 6;
+localparam LOG_AVG_SCALE = LOG_AVG+8;
+localparam LOG_AVG_SYNC_RATE = LOG_RATE;
+localparam WR_PERIOD = ((((INPUT_PERIOD_NS << 16) + INPUT_PERIOD_FNS) + 64'd0) << 16) / ((OUTPUT_PERIOD_NS << 16) + OUTPUT_PERIOD_FNS) / 2**(LOG_RATE+1);
 
 reg [NS_WIDTH-1:0] period_ns_reg = OUTPUT_PERIOD_NS;
 reg [FNS_WIDTH-1:0] period_fns_reg = OUTPUT_PERIOD_FNS;

--- a/rtl/udp_64.v
+++ b/rtl/udp_64.v
@@ -309,6 +309,7 @@ if (CHECKSUM_GEN_ENABLE) begin
         .m_ip_flags(tx_udp_ip_flags),
         .m_ip_fragment_offset(tx_udp_ip_fragment_offset),
         .m_ip_ttl(tx_udp_ip_ttl),
+        .m_ip_protocol(),
         .m_ip_header_checksum(tx_udp_ip_header_checksum),
         .m_ip_source_ip(tx_udp_ip_source_ip),
         .m_ip_dest_ip(tx_udp_ip_dest_ip),


### PR DESCRIPTION
- Converted some local parameter definitions into localparam's which reduces synthesis warnings.
- Added missing port definitions in module instantiations
- Fixed a typo in all sync_signal.v files located in the example folders