### PR TITLE
Fix #124 by converting to integer

### DIFF
--- a/rtl/eth_phy_10g_rx_ber_mon.v
+++ b/rtl/eth_phy_10g_rx_ber_mon.v
@@ -59,7 +59,7 @@ initial begin
     end
 end
 
-parameter COUNT_WIDTH = $clog2(COUNT_125US);
+parameter COUNT_WIDTH = $clog2($rtoi(COUNT_125US));
 
 localparam [1:0]
     SYNC_DATA = 2'b10,

--- a/rtl/eth_phy_10g_rx_watchdog.v
+++ b/rtl/eth_phy_10g_rx_watchdog.v
@@ -68,7 +68,7 @@ initial begin
     end
 end
 
-parameter COUNT_WIDTH = $clog2(COUNT_125US);
+parameter COUNT_WIDTH = $clog2($rtoi(COUNT_125US));
 
 localparam [1:0]
     SYNC_DATA = 2'b10,


### PR DESCRIPTION
Adds $rtoi before using COUNT_125US with $clog2.

There may be other instances of this issue that I didn't encounter.