### PR TITLE
Add devcontainer environment for the repo

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        net-tools less python3 python3-pip \
+        software-properties-common vim build-essential \
+        git curl wget unzip python3-dev \
+        gtkwave iverilog myhdl-cosimulation python3-myhdl
+
+RUN pip3 install cocotb \
+    cocotb-bus cocotb-test cocotbext-axi  \
+    cocotbext-eth cocotbext-pcie  \
+    pytest  scapy \
+    tox pytest-xdist pytest-sugar
+
+RUN git clone https://github.com/myhdl/myhdl && \
+        cd myhdl/cosimulation/icarus && \
+        make && cp myhdl.vpi /usr/lib/aarch64-linux-gnu/ivl/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,65 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/python-3
+{
+	"name": "verilog-ethernet-devenv",
+	
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		"args": { 
+			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local on arm64/Apple Silicon.
+			"VARIANT": "3.10-bullseye",
+			// Options
+			"NODE_VERSION": "lts/*"
+		}
+	},	
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": { 
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
+				"python.linting.enabled": true,
+				"python.linting.pylintEnabled": true,
+				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+			},
+			
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"ms-toolsai.jupyter-renderers",
+				"ms-toolsai.jupyter",
+				"ms-python.vscode-pylance",
+				"ms-vscode.cmake-tools",
+				"leafvmaple.verilog",
+				"mshr-h.VerilogHDL",
+				"GitHub.copilot"
+				// "BenjaminBenais.copilot-theme"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+
+	"runArgs": [
+					"--privileged",
+					"-e", "DISPLAY=host.docker.internal:0",
+    				"-v", "/tmp/.X11-unix:/tmp/.X11-unix"
+				]
+}


### PR DESCRIPTION
The repo's already using `tox`, which is great, but it imposes some workstation/OS requirements which take some time to set up and may present an entry barrier for some. 

Proposing as a complement to this a development path on top of Docker (particularly through VSCode devcontainers) and as a way to get quickly up to speed with a development environment that has simulation requirements pre-installed for doing quick prototyping `verilog-ethernet`.