### PR TITLE
frame_min_count was never updated, so padding was not working

### DIFF
--- a/rtl/axis_baser_tx_64.v
+++ b/rtl/axis_baser_tx_64.v
@@ -662,6 +662,7 @@ always @(posedge clk) begin
 
     swap_lanes_reg <= swap_lanes_next;
 
+    frame_min_count_reg <= frame_min_count_next;
     ifg_count_reg <= ifg_count_next;
     deficit_idle_count_reg <= deficit_idle_count_next;
 
@@ -777,6 +778,7 @@ always @(posedge clk) begin
 
         swap_lanes_reg <= 1'b0;
 
+        frame_min_count_reg <= {MIN_LEN_WIDTH{1'b0}};
         ifg_count_reg <= 8'd0;
         deficit_idle_count_reg <= 2'd0;
 


### PR DESCRIPTION
A line of code was forgotten, causing frame_min_count_reg to never be updated, thus padding was never starting.