### PR TITLE
Fix padding on the 32-bit axis xgmii converter

### DIFF
--- a/rtl/axis_xgmii_tx_32.v
+++ b/rtl/axis_xgmii_tx_32.v
@@ -524,6 +524,8 @@ always @(posedge clk) begin
     ifg_count_reg <= ifg_count_next;
     deficit_idle_count_reg <= deficit_idle_count_next;
 
+    frame_min_count_reg <= frame_min_count_next;
+
     s_tdata_reg <= s_tdata_next;
     s_empty_reg <= s_empty_next;
 
@@ -550,6 +552,8 @@ always @(posedge clk) begin
 
         ifg_count_reg <= 8'd0;
         deficit_idle_count_reg <= 2'd0;
+
+        frame_min_count_reg <= {MIN_LEN_WIDTH{1'b0}};
 
         s_axis_tready_reg <= 1'b0;
 


### PR DESCRIPTION
frame_min_count_reg was not being updated on the 32 bit axis xgmii converter. Thus padding was not working. Updated the reg on clk to have it work.