### PR TITLE
remove `IODDR_STYLE` from `ssio_sdr_in` instantiation in `ssio_sdr_in_diff`

### DIFF
--- a/rtl/ssio_sdr_in_diff.v
+++ b/rtl/ssio_sdr_in_diff.v
@@ -101,7 +101,6 @@ endgenerate
 
 ssio_sdr_in #(
     .TARGET(TARGET),
-    .IODDR_STYLE(IODDR_STYLE),
     .CLOCK_INPUT_STYLE(CLOCK_INPUT_STYLE),
     .WIDTH(WIDTH)
 )


### PR DESCRIPTION

This parameter does not exist and causes parsing failures and fixes #182